### PR TITLE
Add Kubernetes deployment and Docker configuration for monolith app

### DIFF
--- a/monolith/deploy.yaml
+++ b/monolith/deploy.yaml
@@ -18,7 +18,7 @@ metadata:
   labels:
     service: web
   name: ecomm
-  namespace: monolith
+  namespace: monolith-app
 spec:
   ports:
   - name: "80"
@@ -34,7 +34,7 @@ metadata:
   labels:
     service: web
   name: ecomm
-  namespace: monolith
+  namespace: monolith-app
 spec:
   replicas: 1
   selector:
@@ -49,19 +49,18 @@ spec:
       - name: ecomm
         env:
         - name: DB_HOST
-          value:  mysql:3306
+          value: mysql:3306
         - name: DB_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: dbsecret
-              key: password
+              name: mysql-secret
+              key: mysql-password
         - name: DB_USER
           valueFrom:
             secretKeyRef:
-              name: dbsecret
-              key: username
+              name: mysql-secret
+              key: mysql-user
         image: monolith-app:1.0.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
-

--- a/monolith/mysql-deployment.yaml
+++ b/monolith/mysql-deployment.yaml
@@ -1,0 +1,85 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mysql-pv-claim
+  namespace: monolith-app
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 200Mi
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysql-secret
+  namespace: monolith-app
+type: Opaque
+data:
+  mysql-root-password: cm9vdHBhc3N3b3Jk
+  mysql-database: ZWNvbW1lcmNl
+  mysql-user: ZWNvbW1fdXNlcg==
+  mysql-password: ZWNvbW1fcGFzc3dvcmQ=
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql
+  namespace: monolith-app
+spec:
+  ports:
+    - port: 3306
+  selector:
+    app: mysql
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysql
+  namespace: monolith-app
+spec:
+  selector:
+    matchLabels:
+      app: mysql
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: mysql
+    spec:
+      containers:
+      - image: mysql:5.7
+        name: mysql
+        env:
+        - name: MYSQL_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mysql-secret
+              key: mysql-root-password
+        - name: MYSQL_DATABASE
+          valueFrom:
+            secretKeyRef:
+              name: mysql-secret
+              key: mysql-database
+        - name: MYSQL_USER
+          valueFrom:
+            secretKeyRef:
+              name: mysql-secret
+              key: mysql-user
+        - name: MYSQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mysql-secret
+              key: mysql-password
+        ports:
+        - containerPort: 3306
+          name: mysql
+        volumeMounts:
+        - name: mysql-persistent-storage
+          mountPath: /var/lib/mysql
+      volumes:
+      - name: mysql-persistent-storage
+        persistentVolumeClaim:
+          claimName: mysql-pv-claim


### PR DESCRIPTION
This pull request includes significant changes to the deployment configurations for the monolith application, including updates to the `monolith/deploy.yaml` file and the addition of a new `monolith/mysql-deployment.yaml` file. The changes primarily focus on updating namespaces and improving secret management for database credentials.

### Deployment Configuration Updates:

* **Namespace Update**:
  * Changed the namespace from `monolith` to `monolith-app` in `monolith/deploy.yaml`. [[1]](diffhunk://#diff-fb3d6d23336c16c82bee46791ad4950a61993593794e1d273204ab3ab51867c5L21-R21) [[2]](diffhunk://#diff-fb3d6d23336c16c82bee46791ad4950a61993593794e1d273204ab3ab51867c5L37-R37)

* **Secret Management**:
  * Updated database secret references from `dbsecret` to `mysql-secret` and changed the keys accordingly in `monolith/deploy.yaml`.

### New MySQL Deployment Configuration:

* **Persistent Volume Claim**:
  * Added a `PersistentVolumeClaim` for MySQL storage.

* **Secret Creation**:
  * Created a new secret `mysql-secret` with encoded database credentials.

* **MySQL Service and Deployment**:
  * Added a new service and deployment configuration for MySQL, including environment variables for database credentials and volume mounts for persistent storage.