### PR TITLE
Add GitHub workflow for monolith and recommendation service

### DIFF
--- a/.github/workflows/deploy-monolith.yml
+++ b/.github/workflows/deploy-monolith.yml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Build and push monolith image to ACR
       run: |
-        az acr build --registry tahcacr.azurecr.io --image monolith:1.1.1 --image monolith:latest -f Dockerfile .
+        az acr build --registry tahcacr --image monolith-app:1.1.1 --image monolith-app:latest -f Dockerfile .
       working-directory: monolith
 
     - name: Set up kubectl
@@ -37,13 +37,8 @@ jobs:
       with:
         version: 'latest'
 
-    - name: Use kubelogin
-      uses: azure/use-kubelogin@v1
-      with:
-        version: 'v0.0.10'
-
     - name: Get AKS credentials
-      run: az aks get-credentials --resource-group rg_moh_sulaeman --name aks-dev-test
+      run: az aks get-credentials --resource-group rg_moh_sulaeman --name aks-dev-test --admin
 
     - name: Deploy monolith to AKS
       run: kubectl apply -f monolith/deploy.yaml

--- a/.github/workflows/deploy-monolith.yml
+++ b/.github/workflows/deploy-monolith.yml
@@ -1,0 +1,37 @@
+name: Build and Deploy Monolith to AKS
+
+on:
+  push:
+    branches:
+      - main
+      - github-workflow
+    paths:
+      - 'monolith/**'
+
+jobs:
+  build-and-deploy-monolith:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Azure Login
+      uses: azure/login@v1
+      with:
+        creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+    - name: Build and push monolith image to ACR
+      run: |
+        az acr build --registry tahcacr.azurecr.io --image monolith:1.1.1 --image monolith:latest -f monolith/Dockerfile .
+
+    - name: Set up kubectl
+      uses: azure/setup-kubectl@v1
+      with:
+        version: 'latest'
+
+    - name: Get AKS credentials
+      run: az aks get-credentials --resource-group rg_moh_sulaeman --name aks-dev-test --admin
+
+    - name: Deploy monolith to AKS
+      run: kubectl apply -f monolith/deploy.yaml

--- a/.github/workflows/deploy-monolith.yml
+++ b/.github/workflows/deploy-monolith.yml
@@ -6,11 +6,13 @@ on:
       - main
     paths:
       - 'monolith/**'
+      - '.github/workflows/deploy-monolith.yml'
   pull_request:
     branches:
       - github-workflow
     paths:
       - 'monolith/**'
+      - '.github/workflows/deploy-monolith.yml'
 
 jobs:
   build-and-deploy-monolith:

--- a/.github/workflows/deploy-monolith.yml
+++ b/.github/workflows/deploy-monolith.yml
@@ -37,11 +37,11 @@ jobs:
       with:
         version: 'latest'
 
-    - name: Install kubelogin
-      run: |
-        sudo az aks install-cli
-        sudo apt-get update
-        sudo apt-get install -y kubelogin
+    # - name: Install kubelogin
+    #   run: |
+    #     sudo az aks install-cli
+    #     sudo apt-get update
+    #     sudo apt-get install -y kubelogin
 
     - name: Get AKS credentials
       run: az aks get-credentials --resource-group rg_moh_sulaeman --name aks-dev-test

--- a/.github/workflows/deploy-monolith.yml
+++ b/.github/workflows/deploy-monolith.yml
@@ -29,7 +29,8 @@ jobs:
 
     - name: Build and push monolith image to ACR
       run: |
-        az acr build --registry tahcacr.azurecr.io --image monolith:1.1.1 --image monolith:latest -f monolith/Dockerfile .
+        az acr build --registry tahcacr.azurecr.io --image monolith:1.1.1 --image monolith:latest -f Dockerfile .
+      working-directory: monolith
 
     - name: Set up kubectl
       uses: azure/setup-kubectl@v1

--- a/.github/workflows/deploy-monolith.yml
+++ b/.github/workflows/deploy-monolith.yml
@@ -38,7 +38,7 @@ jobs:
         version: 'latest'
 
     - name: Get AKS credentials
-      run: az aks get-credentials --resource-group rg_moh_sulaeman --name aks-dev-test --admin
+      run: az aks get-credentials --resource-group rg_moh_sulaeman --name aks-dev-test
 
     - name: Deploy monolith to AKS
       run: kubectl apply -f monolith/deploy.yaml

--- a/.github/workflows/deploy-monolith.yml
+++ b/.github/workflows/deploy-monolith.yml
@@ -37,6 +37,12 @@ jobs:
       with:
         version: 'latest'
 
+    - name: Install kubelogin
+      run: |
+        sudo az aks install-cli
+        sudo apt-get update
+        sudo apt-get install -y kubelogin
+
     - name: Get AKS credentials
       run: az aks get-credentials --resource-group rg_moh_sulaeman --name aks-dev-test
 

--- a/.github/workflows/deploy-monolith.yml
+++ b/.github/workflows/deploy-monolith.yml
@@ -9,7 +9,7 @@ on:
       - '.github/workflows/deploy-monolith.yml'
   pull_request:
     branches:
-      - github-workflow
+      - main
     paths:
       - 'monolith/**'
       - '.github/workflows/deploy-monolith.yml'

--- a/.github/workflows/deploy-monolith.yml
+++ b/.github/workflows/deploy-monolith.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'monolith/**'
+  pull_request:
+    branches:
       - github-workflow
     paths:
       - 'monolith/**'

--- a/.github/workflows/deploy-mysql.yml
+++ b/.github/workflows/deploy-mysql.yml
@@ -1,4 +1,4 @@
-name: Deploy MySQL to AKS
+name: Deploy MySQL to AKS (1st setup only)
 
 on:
   push:

--- a/.github/workflows/deploy-mysql.yml
+++ b/.github/workflows/deploy-mysql.yml
@@ -32,13 +32,8 @@ jobs:
       with:
         version: 'latest'
 
-    - name: Use kubelogin
-      uses: azure/use-kubelogin@v1
-      with:
-        version: 'v0.0.10'
-
     - name: Get AKS credentials
-      run: az aks get-credentials --resource-group rg_moh_sulaeman --name aks-dev-test
+      run: az aks get-credentials --resource-group rg_moh_sulaeman --name aks-dev-test --admin
 
     - name: Deploy MySQL to AKS
       run: kubectl apply -f monolith/mysql-deployment.yaml

--- a/.github/workflows/deploy-mysql.yml
+++ b/.github/workflows/deploy-mysql.yml
@@ -1,21 +1,21 @@
-name: Build and Deploy Monolith to AKS
+name: Deploy MySQL to AKS
 
 on:
   push:
     branches:
       - main
     paths:
-      - 'monolith/**'
-      - '.github/workflows/deploy-monolith.yml'
+      - 'monolith/mysql-deployment.yaml'
+      - '.github/workflows/deploy-mysql.yml'
   pull_request:
     branches:
       - main
     paths:
-      - 'monolith/**'
-      - '.github/workflows/deploy-monolith.yml'
+      - 'monolith/mysql-deployment.yaml'
+      - '.github/workflows/deploy-mysql.yml'
 
 jobs:
-  build-and-deploy-monolith:
+  deploy-mysql:
     runs-on: ubuntu-latest
 
     steps:
@@ -26,11 +26,6 @@ jobs:
       uses: azure/login@v1
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
-
-    - name: Build and push monolith image to ACR
-      run: |
-        az acr build --registry tahcacr.azurecr.io --image monolith:1.1.1 --image monolith:latest -f Dockerfile .
-      working-directory: monolith
 
     - name: Set up kubectl
       uses: azure/setup-kubectl@v1
@@ -45,5 +40,5 @@ jobs:
     - name: Get AKS credentials
       run: az aks get-credentials --resource-group rg_moh_sulaeman --name aks-dev-test
 
-    - name: Deploy monolith to AKS
-      run: kubectl apply -f monolith/deploy.yaml
+    - name: Deploy MySQL to AKS
+      run: kubectl apply -f monolith/mysql-deployment.yaml

--- a/.github/workflows/deploy-recommendation-service.yml
+++ b/.github/workflows/deploy-recommendation-service.yml
@@ -37,11 +37,10 @@ jobs:
             with:
               version: 'latest'
 
-        #   - name: Install kubelogin
-        #     run: |
-        #         sudo az aks install-cli
-        #         sudo apt-get update
-        #         sudo apt-get install -y kubelogin
+          - name: Set up kubelogin
+            uses: azure/setup-kubelogin@v1
+            with:
+              version: 'v0.0.10'
 
           - name: Get AKS credentials
             run: az aks get-credentials --resource-group rg_moh_sulaeman --name aks-dev-test

--- a/.github/workflows/deploy-recommendation-service.yml
+++ b/.github/workflows/deploy-recommendation-service.yml
@@ -28,8 +28,9 @@ jobs:
               creds: ${{ secrets.AZURE_CREDENTIALS }}
 
           - name: Build and push recommendation-service image to ACR
+            working-directory: microservices/recommendation-service-python
             run: |
-              az acr build --registry tahcacr.azurecr.io --image recommendation-service:1.0.0 --image recommendation-service:latest -f microservices/recommendation-service-python/Dockerfile .
+              az acr build --registry tahcacr.azurecr.io --image recommendation-service:1.0.0 --image recommendation-service:latest -f Dockerfile .
 
           - name: Set up kubectl
             uses: azure/setup-kubectl@v1

--- a/.github/workflows/deploy-recommendation-service.yml
+++ b/.github/workflows/deploy-recommendation-service.yml
@@ -30,20 +30,15 @@ jobs:
           - name: Build and push recommendation-service image to ACR
             working-directory: microservices/recommendation-service-python
             run: |
-              az acr build --registry tahcacr.azurecr.io --image recommendation-service:1.0.0 --image recommendation-service:latest -f Dockerfile .
+              az acr build --registry tahcacr --image recommendation-service:1.0.0 --image recommendation-service:latest -f Dockerfile .
 
           - name: Set up kubectl
             uses: azure/setup-kubectl@v1
             with:
               version: 'latest'
 
-          - name: Set up kubelogin
-            uses: azure/use-kubelogin@v1
-            with:
-              version: 'v0.0.10'
-
           - name: Get AKS credentials
-            run: az aks get-credentials --resource-group rg_moh_sulaeman --name aks-dev-test
+            run: az aks get-credentials --resource-group rg_moh_sulaeman --name aks-dev-test --admin
 
           - name: Deploy recommendation service to AKS
             run: kubectl apply -f microservices/recommendation-service-python/deploy-recommendation-service.yaml

--- a/.github/workflows/deploy-recommendation-service.yml
+++ b/.github/workflows/deploy-recommendation-service.yml
@@ -1,0 +1,37 @@
+name: Build and Deploy Recommendation Service to AKS
+
+on:
+    push:
+        branches:
+            - main
+            - github-workflow
+        paths:
+            - 'microservices/recommendation-service-python/**'
+
+jobs:
+    build-and-deploy-recommendation-service:
+        runs-on: ubuntu-latest
+
+        steps:
+          - name: Checkout code
+            uses: actions/checkout@v2
+
+          - name: Azure Login
+            uses: azure/login@v1
+            with:
+              creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+          - name: Build and push recommendation-service image to ACR
+            run: |
+              az acr build --registry tahcacr.azurecr.io --image recommendation-service:1.0.0 --image recommendation-service:latest -f microservices/recommendation-service-python/Dockerfile .
+
+          - name: Set up kubectl
+            uses: azure/setup-kubectl@v1
+            with:
+              version: 'latest'
+
+          - name: Get AKS credentials
+            run: az aks get-credentials --resource-group rg_moh_sulaeman --name aks-dev-test --admin
+
+          - name: Deploy recommendation service to AKS
+            run: kubectl apply -f microservices/recommendation-service-python/deploy-recommendation-service.yaml

--- a/.github/workflows/deploy-recommendation-service.yml
+++ b/.github/workflows/deploy-recommendation-service.yml
@@ -37,11 +37,11 @@ jobs:
             with:
               version: 'latest'
 
-          - name: Install kubelogin
-            run: |
-                sudo az aks install-cli
-                sudo apt-get update
-                sudo apt-get install -y kubelogin
+        #   - name: Install kubelogin
+        #     run: |
+        #         sudo az aks install-cli
+        #         sudo apt-get update
+        #         sudo apt-get install -y kubelogin
 
           - name: Get AKS credentials
             run: az aks get-credentials --resource-group rg_moh_sulaeman --name aks-dev-test

--- a/.github/workflows/deploy-recommendation-service.yml
+++ b/.github/workflows/deploy-recommendation-service.yml
@@ -4,6 +4,10 @@ on:
     push:
         branches:
             - main
+        paths:
+            - 'microservices/recommendation-service-python/**'
+    pull_request:
+        branches:
             - github-workflow
         paths:
             - 'microservices/recommendation-service-python/**'

--- a/.github/workflows/deploy-recommendation-service.yml
+++ b/.github/workflows/deploy-recommendation-service.yml
@@ -6,11 +6,13 @@ on:
             - main
         paths:
             - 'microservices/recommendation-service-python/**'
+            - '.github/workflows/deploy-recommendation-service.yml'
     pull_request:
         branches:
             - github-workflow
         paths:
             - 'microservices/recommendation-service-python/**'
+            - '.github/workflows/deploy-recommendation-service.yml'
 
 jobs:
     build-and-deploy-recommendation-service:

--- a/.github/workflows/deploy-recommendation-service.yml
+++ b/.github/workflows/deploy-recommendation-service.yml
@@ -9,7 +9,7 @@ on:
             - '.github/workflows/deploy-recommendation-service.yml'
     pull_request:
         branches:
-            - github-workflow
+            - main
         paths:
             - 'microservices/recommendation-service-python/**'
             - '.github/workflows/deploy-recommendation-service.yml'

--- a/.github/workflows/deploy-recommendation-service.yml
+++ b/.github/workflows/deploy-recommendation-service.yml
@@ -37,6 +37,12 @@ jobs:
             with:
               version: 'latest'
 
+          - name: Install kubelogin
+            run: |
+                sudo az aks install-cli
+                sudo apt-get update
+                sudo apt-get install -y kubelogin
+
           - name: Get AKS credentials
             run: az aks get-credentials --resource-group rg_moh_sulaeman --name aks-dev-test
 

--- a/.github/workflows/deploy-recommendation-service.yml
+++ b/.github/workflows/deploy-recommendation-service.yml
@@ -38,7 +38,7 @@ jobs:
               version: 'latest'
 
           - name: Get AKS credentials
-            run: az aks get-credentials --resource-group rg_moh_sulaeman --name aks-dev-test --admin
+            run: az aks get-credentials --resource-group rg_moh_sulaeman --name aks-dev-test
 
           - name: Deploy recommendation service to AKS
             run: kubectl apply -f microservices/recommendation-service-python/deploy-recommendation-service.yaml

--- a/.github/workflows/deploy-recommendation-service.yml
+++ b/.github/workflows/deploy-recommendation-service.yml
@@ -38,7 +38,7 @@ jobs:
               version: 'latest'
 
           - name: Set up kubelogin
-            uses: azure/setup-kubelogin@v1
+            uses: azure/use-kubelogin@v1
             with:
               version: 'v0.0.10'
 

--- a/microservices/recommendation-service-python/deploy-recommendation-service.yaml
+++ b/microservices/recommendation-service-python/deploy-recommendation-service.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: recommendation-service
-        image: recommendation-service:1.0.0
+        image: tahcacr.azurecr.io/recommendation-service:1.0.0
         ports:
         - containerPort: 8001
 ---

--- a/monolith/deploy.yaml
+++ b/monolith/deploy.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   ports:
   - name: "80"
-    port: 5005
+    port: 80
     targetPort: 8080
   selector:
     service: web
@@ -60,7 +60,7 @@ spec:
             secretKeyRef:
               name: mysql-secret
               key: mysql-user
-        image: monolith-app:1.1.1
+        image: tahcacr.azurecr.io/monolith-app:1.1.1
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080

--- a/monolith/mysql-deployment.yaml
+++ b/monolith/mysql-deployment.yaml
@@ -52,6 +52,8 @@ spec:
       containers:
       - image: mysql:5.7
         name: mysql
+        args:
+          - "--ignore-db-dir=lost+found"
         env:
         - name: MYSQL_ROOT_PASSWORD
           valueFrom:


### PR DESCRIPTION
This pull request introduces two new GitHub Actions workflows to automate the build and deployment processes for the monolith and recommendation service to Azure Kubernetes Service (AKS).

### New Workflows for Build and Deployment:

* **Monolith Service:**
  * Added a workflow to build and deploy the monolith service to AKS on pushes to the `main` branch and pull requests to the `github-workflow` branch. (`.github/workflows/deploy-monolith.yml`)

* **Recommendation Service:**
  * Added a workflow to build and deploy the recommendation service to AKS on pushes to the `main` branch and pull requests to the `github-workflow` branch. (`.github/workflows/deploy-recommendation-service.yml`)